### PR TITLE
chore: add halving schedule reward depletion logic and update tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,7 @@ pub fn validate_block_height(height: i64) -> (bool, String) {
 pub fn halving_schedule(blocks: &[u64]) -> HashMap<u64, u64> {
     // TODO: Base reward is 50 * 100_000_000 sats; halving interval is 210_000 blocks
     // TODO: For each block: halvings = block / 210_000; reward = base >> halvings
+    // TODO: Account for reward depletion: reward reaches 0 at block 6,930,000 (33rd halving)
     // TODO: Insert (block, reward) into the result HashMap
     todo!()
 }

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -168,11 +168,14 @@ mod exercise_tests {
 
     #[test]
     fn test_halving_schedule() {
-        let result = halving_schedule(&[0, 210_000, 420_000, 630_000]);
+        let result = halving_schedule(&[0, 210_000, 420_000, 630_000, 6_720_000, 6_930_000, 13_440_000]);
         assert_eq!(result.get(&0), Some(&5_000_000_000));
         assert_eq!(result.get(&210_000), Some(&2_500_000_000));
         assert_eq!(result.get(&420_000), Some(&1_250_000_000));
         assert_eq!(result.get(&630_000), Some(&625_000_000));
+        assert_eq!(result.get(&6_720_000), Some(&1));
+        assert_eq!(result.get(&6_930_000), Some(&0));
+        assert_eq!(result.get(&13_440_000), Some(&0));
     }
 
     #[test]


### PR DESCRIPTION
I noticed that the test doesn't account for when the block reward is zero. Given that we're using the bitwise right shift operation `>>` for the halving division, the test will panic when we get to the 33rd halving i.e., when the block reward is 0 sats (although the test isn't accounting for that now; blocks stop at 630_000).

In the screenshot below, I edited the test to include the block where there will be no block reward (6,930,000), and the program crashed.
<img width="1059" height="379" alt="Screenshot 2026-06-03 at 13 22 31" src="https://github.com/user-attachments/assets/389670a1-f09a-4ae5-a835-b6b9bdd22d04" />

I believe adding this check helps the user understand that mining rewards will eventually deplete to zero and will have to make their program fail-proof for this reason.
This PR:
- Added a note in the `halving_schedule` function to account for reward depletion at block 6,930,000.
- Updated unit tests to include additional block heights and their corresponding rewards, verifying that the reward reaches 0 at the specified blocks.